### PR TITLE
revert: "fix: Update the goreleaser archives format"

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -6,29 +6,29 @@ builds:
   - dir: provider
     env:
       - CGO_ENABLED=0
-    mod_timestamp: "{{ .CommitTimestamp }}"
+    mod_timestamp: '{{ .CommitTimestamp }}'
     flags:
       - -trimpath
     ldflags:
-      - "-s -w -X main.version={{ .Version }} -X main.commit={{ .Commit }}"
+      - '-s -w -X main.version={{ .Version }} -X main.commit={{ .Commit }}'
     goos:
       - linux
       - darwin
     goarch:
       - amd64
       - arm64
-    binary: "{{ .ProjectName }}_v{{ .Version }}"
+    binary: '{{ .ProjectName }}_v{{ .Version }}'
 
 archives:
-  - formats: ["zip"]
-    name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
+  - format: zip
+    name_template: '{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}'
 
 checksum:
   algorithm: sha256
-  name_template: "{{ .ProjectName }}_{{ .Version }}_SHA256SUMS"
+  name_template: '{{ .ProjectName }}_{{ .Version }}_SHA256SUMS'
   extra_files:
-    - glob: "terraform-registry-manifest.json"
-      name_template: "{{ .ProjectName }}_{{ .Version }}_manifest.json"
+    - glob: 'terraform-registry-manifest.json'
+      name_template: '{{ .ProjectName }}_{{ .Version }}_manifest.json'
 
 signs:
   - artifacts: checksum
@@ -46,8 +46,8 @@ signs:
       - "${artifact}"
 
 release:
-  github:
+  github: 
   prerelease: auto
   extra_files:
-    - glob: "terraform-registry-manifest.json"
-      name_template: "{{ .ProjectName }}_{{ .Version }}_manifest.json"
+    - glob: 'terraform-registry-manifest.json'
+      name_template: '{{ .ProjectName }}_{{ .Version }}_manifest.json'

--- a/provider/.goreleaser.yml
+++ b/provider/.goreleaser.yml
@@ -6,29 +6,29 @@ builds:
   - dir: provider
     env:
       - CGO_ENABLED=0
-    mod_timestamp: "{{ .CommitTimestamp }}"
+    mod_timestamp: '{{ .CommitTimestamp }}'
     flags:
       - -trimpath
     ldflags:
-      - "-s -w -X main.version={{ .Version }} -X main.commit={{ .Commit }}"
+      - '-s -w -X main.version={{ .Version }} -X main.commit={{ .Commit }}'
     goos:
       - linux
       - darwin
     goarch:
       - amd64
       - arm64
-    binary: "{{ .ProjectName }}_v{{ .Version }}"
+    binary: '{{ .ProjectName }}_v{{ .Version }}'
 
 archives:
-  - format: ["zip"]
-    name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
+  - format: zip
+    name_template: '{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}'
 
 checksum:
   algorithm: sha256
-  name_template: "{{ .ProjectName }}_{{ .Version }}_SHA256SUMS"
+  name_template: '{{ .ProjectName }}_{{ .Version }}_SHA256SUMS'
   extra_files:
-    - glob: "terraform-registry-manifest.json"
-      name_template: "{{ .ProjectName }}_{{ .Version }}_manifest.json"
+    - glob: 'terraform-registry-manifest.json'
+      name_template: '{{ .ProjectName }}_{{ .Version }}_manifest.json'
 
 signs:
   - artifacts: checksum
@@ -47,5 +47,5 @@ signs:
 
 release:
   extra_files:
-    - glob: "terraform-registry-manifest.json"
-      name_template: "{{ .ProjectName }}_{{ .Version }}_manifest.json"
+    - glob: 'terraform-registry-manifest.json'
+      name_template: '{{ .ProjectName }}_{{ .Version }}_manifest.json'


### PR DESCRIPTION
https://github.com/petsinc/terraform-provider-telnyx/pull/9 [failed](https://github.com/petsinc/terraform-provider-telnyx/actions/runs/17979853275/job/51142693227) with:

```
/opt/hostedtoolcache/goreleaser-action/2.12.2/x64/goreleaser release
yaml: unmarshal errors:
  line 23: cannot unmarshal !!seq into string
```

So.... oh well.