### PR TITLE
feat: Add an ImportState method to the fqdn_resource

### DIFF
--- a/provider/provider/internal/provider/fqdn_resource.go
+++ b/provider/provider/internal/provider/fqdn_resource.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
@@ -201,6 +202,10 @@ func (r *FQDNResource) Delete(ctx context.Context, req resource.DeleteRequest, r
 		)
 		return
 	}
+}
+
+func (r *FQDNResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+	resource.ImportStatePassthroughID(ctx, path.Root("id"), req, resp)
 }
 
 func setFQDNState(ctx context.Context, state *FQDNResourceModel, fqdn *telnyx.FQDN) {


### PR DESCRIPTION
Implements `import` on the `fqdn_resource`. You can use this like `terraform import your.resource {fqdn.id}`. I scraped the ID of the resource I wanted to import from a call to [List FQDNs](https://api.telnyx.com/v2/fqdns).

---

I already used this to import state and unblock our deploy pipeline... so am sure it works. It is also vibe coded, however, b/c I'm a terraform noob.... so also lmk if you see any red flags.