### PR TITLE
feat: Add ImportState to messaging_profile and texml_application resources

### DIFF
--- a/provider/provider/internal/provider/messaging_profile_resource.go
+++ b/provider/provider/internal/provider/messaging_profile_resource.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/listdefault"
@@ -17,7 +18,8 @@ import (
 )
 
 var (
-	_ resource.Resource = &MessagingProfileResource{}
+	_ resource.Resource                = &MessagingProfileResource{}
+	_ resource.ResourceWithImportState = &MessagingProfileResource{}
 )
 
 func NewMessagingProfileResource() resource.Resource {
@@ -245,4 +247,8 @@ func (r *MessagingProfileResource) Delete(ctx context.Context, req resource.Dele
 	if err != nil {
 		resp.Diagnostics.AddError("Error deleting messaging profile", err.Error())
 	}
+}
+
+func (r *MessagingProfileResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+	resource.ImportStatePassthroughID(ctx, path.Root("id"), req, resp)
 }

--- a/provider/provider/internal/provider/texml_application_resource.go
+++ b/provider/provider/internal/provider/texml_application_resource.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
@@ -20,8 +21,9 @@ import (
 )
 
 var (
-	_ resource.Resource              = &TeXMLApplicationResource{}
-	_ resource.ResourceWithConfigure = &TeXMLApplicationResource{}
+	_ resource.Resource                = &TeXMLApplicationResource{}
+	_ resource.ResourceWithConfigure   = &TeXMLApplicationResource{}
+	_ resource.ResourceWithImportState = &TeXMLApplicationResource{}
 )
 
 func NewTeXMLApplicationResource() resource.Resource {
@@ -569,6 +571,10 @@ func (r *TeXMLApplicationResource) Delete(ctx context.Context, req resource.Dele
 	}
 
 	resp.State.RemoveResource(ctx)
+}
+
+func (r *TeXMLApplicationResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+	resource.ImportStatePassthroughID(ctx, path.Root("id"), req, resp)
 }
 
 func setStateFromTeXMLApplicationResponse(state *TeXMLApplicationResourceModel, application *telnyx.TeXMLApplication) {


### PR DESCRIPTION
## Summary

- `messaging_profile` and `texml_application` resources can now be imported via `terraform import`
- Uses `ImportStatePassthroughID` to grab the resource ID from the import arg so `Read` can fetch the rest of the state
- Same pattern as `credential_connection_resource` and `fqdn_resource`

## Test plan

- [ ] `go build ./...` passes
- [ ] `terraform import telnyx_messaging_profile.<name> <id>` works
- [ ] `terraform import telnyx_texml_application.<name> <id>` works
- [ ] `terraform plan` after import shows no unexpected diff